### PR TITLE
Created sm.modpackAPI for other mods to use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /cache/
 /description.json
 preview.png
+.vscode/

--- a/Scripts/interactable/NumberLogic/CounterBlock.lua
+++ b/Scripts/interactable/NumberLogic/CounterBlock.lua
@@ -57,23 +57,52 @@ CounterBlock.digs = {
 	["577d07ff"] = -0.00000001
 }
 
+local counters = {}
+
+sm.modpackAPI = sm.modpackAPI or {}
+sm.modpackAPI.counter = {}
+
+function sm.modpackAPI.counter.setValue(interactableid, value)
+    local counter = counters[interactableid]
+    if counter then
+        counter.power = value
+        counter.interactable:setPower(value)
+        counter.needssave = true
+        return true
+    end
+	return false
+end
+
+function sm.modpackAPI.counter.getValue(interactableid)
+    local counter = counters[interactableid]
+    if counter then
+        return counter.power
+    end
+    return nil
+end
 
 function CounterBlock.server_onRefresh( self )
-	sm.isDev = true
-	self:server_onCreate()
+    sm.isDev = true
+    self:server_onCreate()
 end
 
 function CounterBlock.server_onCreate( self )
-	local stored = self.storage:load()
-	if stored then
-		if type(stored) == "table" then -- compatible with old versions (they used a jank workaround for a bug back then)
-			self.power = tonumber(stored[1])
-		else
-			self.power = tonumber(stored)
-		end
-		self.interactable:setPower(self.power)
-	end
-	sm.interactable.setValue(self.interactable, self.power)
+    local stored = self.storage:load()
+    if stored then
+        if type(stored) == "table" then -- compatible with old versions (they used a jank workaround for a bug back then)
+            self.power = tonumber(stored[1])
+        else
+            self.power = tonumber(stored)
+        end
+        self.interactable:setPower(self.power)
+    end
+    sm.interactable.setValue(self.interactable, self.power)
+
+    counters[self.interactable.id] = self
+end
+
+function CounterBlock.server_onDestroy(self)
+	counters[self.interactable.id] = nil
 end
 
 function CounterBlock.server_onFixedUpdate( self, dt )

--- a/Scripts/interactable/NumberOut/SmartSensor.lua
+++ b/Scripts/interactable/NumberOut/SmartSensor.lua
@@ -42,6 +42,27 @@ for k,v in pairs(SmartSensor.modes) do
    SmartSensor.savemodes[v.value] = k
 end
 
+local smartsensors = {}
+
+sm.modpackAPI = sm.modpackAPI or {}
+sm.modpackAPI.smartsensor = {}
+
+function sm.modpackAPI.smartsensor.setMode(interactableid, mode)
+    local sensor = smartsensors[interactableid]
+    if sensor then
+        sensor:sv_setMode({ mode = mode })
+        return true
+    end
+    return false
+end
+
+function sm.modpackAPI.smartsensor.getMode(interactableid)
+    local sensor = smartsensors[interactableid]
+    if sensor then
+        return sensor.mode
+    end
+    return nil
+end
 
 function SmartSensor.server_onRefresh( self )
 	sm.isDev = true
@@ -49,12 +70,18 @@ function SmartSensor.server_onRefresh( self )
 end
 
 function SmartSensor.server_onCreate( self )
-	local stored = self.storage:load()
-	if stored then
-		self.mode = self.savemodes[stored]
-	else
-		self.storage:save(self.modes[self.mode].value)
-	end
+    local stored = self.storage:load()
+    if stored then
+        self.mode = self.savemodes[stored]
+    else
+        self.storage:save(self.modes[self.mode].value)
+    end
+
+    smartsensors[self.interactable.id] = self
+end
+
+function SmartSensor.server_onDestroy(self)
+	smartsensors[self.interactable.id] = nil
 end
 
 function SmartSensor.server_onFixedUpdate( self, dt )

--- a/Scripts/interactable/Orientation/Orienter.lua
+++ b/Scripts/interactable/Orientation/Orienter.lua
@@ -129,6 +129,28 @@ end
 
 Orienter.modeCount = #Orienter.modetable
 
+local orientBlocks = {}
+
+sm.modpackAPI = sm.modpackAPI or {}
+sm.modpackAPI.orienter = {}
+
+function sm.modpackAPI.orienter.setMode(interactableid, mode)
+    local orienter = orientBlocks[interactableid]
+    if orienter then
+        orienter:sv_changeMode({ mode = mode })
+        return true
+    end
+    return false
+end
+
+function sm.modpackAPI.orienter.getMode(interactableid)
+	local orienter = orientBlocks[interactableid]
+	if orienter then
+		return orienter.mode
+	end
+	return nil
+end
+
 function Orienter.server_onCreate( self )
 	self:server_init()
 end
@@ -154,7 +176,8 @@ function Orienter.server_init( self )
 	self.storage:save(self.modetable[self.mode].savevalue)
 
 	if not orienters then orienters = {} end
-	self.id = self.shape.id
+    self.id = self.shape.id
+	orientBlocks[self.interactable.id] = self
 end
 
 function Orienter.client_onCreate(self)
@@ -398,6 +421,7 @@ end
 
 function Orienter.server_onDestroy(self)
 	orienters[self.id] = nil
+	orientBlocks[self.interactable.id] = nil
 end
 
 function Orienter.getplayer(self, data)  --self:getplayer({useexceptionlist = false, minrange = nil, maxrange = nil, offset = 1, tryid = nil, ignorejammers = false})


### PR DESCRIPTION
Added modpack API for other mods to use. This will be especially helpful with mods that want to interface with data stored in memory panels and counters. I added the other methods because I saw no harm in doing so.

The following methods have been added:

sm.modpackAPI.memorypanel.write (compatible with old sm.modpack.memorypanelWrite)
sm.modpackAPI.memorypanel.read
sm.modpackAPI.memorypanel.writeValue
sm.modpackAPI.memorypanel.readValue

sm.modpackAPI.counter.setValue
sm.modpackAPI.counter.getValue

sm.modpackAPI.mathblock.getMode
sm.modpackAPI.mathblock.setMode

sm.modpackAPI.wirelessblock.setIsSender
sm.modpackAPI.wirelessblock.getIsSender
sm.modpackAPI.wirelessblock.getWirelessData
sm.modpackAPI.wirelessblock.getWirelessDataValues

sm.modpackAPI.smartsensor.setMode
sm.modpackAPI.smartsensor.getMode

sm.modpackAPI.orienter.setMode
sm.modpackAPI.orienter.getMode