### PR TITLE
Add chapter 2 bots (totebot yellow/red/blue & cablebot) support to Orienter

### DIFF
--- a/Gui/Layouts/Orienter.layout
+++ b/Gui/Layouts/Orienter.layout
@@ -178,7 +178,15 @@
 							<Property key="NeedKey" value="false" />
 						</Widget>
 					</Widget>
-					<Widget type="Button" skin="BeaconIconBorder" name="UnitsWoc" position_real="0.1702127659574468 0.6944444444444444 0.1595744680851064 0.2777777777777778">
+					<Widget type="Button" skin="BeaconIconBorder" name="UnitsCablebot" position_real="0.4893617021276596 0.4444444444444444 0.1702127659574468 0.25">
+					<Widget type="TextBox" skin="TextBox" position_real="0.0625 0.1111111111111111 0.875 0.7777777777777778">
+						<Property key="Caption" value="Cablebot" />
+						<Property key="TextAlign" value="Center" />
+						<Property key="NeedMouse" value="false" />
+						<Property key="NeedKey" value="false" />
+					</Widget>
+				</Widget>
+				<Widget type="Button" skin="BeaconIconBorder" name="UnitsWoc" position_real="0.1702127659574468 0.6944444444444444 0.1595744680851064 0.2777777777777778">
 						<Widget type="TextBox" skin="TextBox" position_real="0.06666666666666667 0.1 0.8666666666666667 0.7">
 							<Property key="Caption" value="Wocs" />
 							<Property key="TextAlign" value="Center" />

--- a/Gui/Layouts/Orienter.layout
+++ b/Gui/Layouts/Orienter.layout
@@ -1,197 +1,209 @@
-<?xml version="1.0" encoding="UTF-8" ?>
 <MyGUI type="Layout" version="3.2.0">
-	<Widget type="Widget" skin="PanelEmpty" name="BackPanel" position_real="0 0 0.265625 0.636111">
-		<Widget type="Widget" skin="BeaconBG" position_real="0 0 1 0.716157">
-			<Widget type="TextBox" skin="TextBox" position_real="0 0 1 0.243902">
+	<Widget type="Widget" skin="PanelEmpty" name="BackPanel" position_real="0 0 0.265625 0.8">
+		<Widget type="Widget" skin="BeaconBG" position_real="0 0 0.9901960784313726 0.9895833333333334">
+			<Widget type="TextBox" skin="TextBox" position_real="0 0 1.00990099009901 0.16374269005847952">
 				<Property key="Caption" value="Choose a mode" />
 				<Property key="TextAlign" value="Center" />
 				<Property key="FontName" value="SM_HeaderLarge_Wide" />
 			</Widget>
-			<Widget type="Widget" skin="PanelEmpty" position_real="0.0411765 0.286585 0.917647 0.634146">
-				<Widget type="TextBox" skin="TextBox" position_real="0 0 0.5 0.1">
+			<Widget type="Widget" skin="PanelEmpty" position_real="0.039603960396039604 0.15204678362573099 0.9306930693069307 0.5730994152046783">
+				<Widget type="TextBox" skin="TextBox" position_real="0 0 0.4978723404255319 0.08571428571428572">
 					<Property key="Caption" value="Target" />
 					<Property key="TextAlign" value="Left VCenter" />
 					<Property key="FontName" value="SM_ButtonSmallBold" />
 				</Widget>
-				<Widget type="Button" skin="BeaconIconBorder" name="TargetDistance" position_real="0.5 0 0.5 0.1">
-					<Widget type="TextBox" skin="TextBox" name="ButtonTextDistance" position_real="0.0769231 0.0769231 0.846154 0.846154">
+				<Widget type="Button" skin="BeaconIconBorder" name="TargetDistance" position_real="0.4978723404255319 0 0.4978723404255319 0.08571428571428572">
+					<Widget type="TextBox" skin="TextBox" name="ButtonTextDistance" position_real="0.08547008547008547 0.11904761904761904 0.8333333333333334 0.5952380952380952">
 						<Property key="Caption" value="Orienter Distance Reader" />
 						<Property key="TextAlign" value="Center" />
 						<Property key="NeedMouse" value="false" />
 						<Property key="NeedKey" value="false" />
 					</Widget>
 				</Widget>
-				<Widget type="Button" skin="BeaconIconBorder" name="TargetWorld" position_real="0 0.15 0.166667 0.25">
-					<Widget type="TextBox" skin="TextBox" name="ButtonTextWorld" position_real="0.0769231 0.0769231 0.846154 0.846154">
+				<Widget type="Button" skin="BeaconIconBorder" name="TargetWorld" position_real="0 0.11224489795918367 0.1702127659574468 0.16326530612244897">
+					<Widget type="TextBox" skin="TextBox" name="ButtonTextWorld" position_real="0.0625 0.125 0.875 0.75">
 						<Property key="Caption" value="World" />
 						<Property key="TextAlign" value="Center" />
 						<Property key="NeedMouse" value="false" />
 						<Property key="NeedKey" value="false" />
 					</Widget>
 				</Widget>
-				<Widget type="Button" skin="BeaconIconBorder" name="TargetPlayer" position_real="0.166667 0.15 0.166667 0.25">
-					<Widget type="TextBox" skin="TextBox" name="ButtonTextPlayer" position_real="0.0769231 0.0769231 0.846154 0.846154">
+				<Widget type="Button" skin="BeaconIconBorder" name="TargetPlayer" position_real="0.1702127659574468 0.11224489795918367 0.1702127659574468 0.16326530612244897">
+					<Widget type="TextBox" skin="TextBox" name="ButtonTextPlayer" position_real="0.0625 0.125 0.875 0.75">
 						<Property key="Caption" value="Player" />
 						<Property key="TextAlign" value="Center" />
 						<Property key="NeedMouse" value="false" />
 						<Property key="NeedKey" value="false" />
 					</Widget>
 				</Widget>
-				<Widget type="Button" skin="BeaconIconBorder" name="TargetCamera" position_real="0.333333 0.15 0.166667 0.25">
-					<Widget type="TextBox" skin="TextBox" name="ButtonTextCamera" position_real="0.0769231 0.0769231 0.846154 0.846154">
+				<Widget type="Button" skin="BeaconIconBorder" name="TargetCamera" position_real="0.32978723404255317 0.11224489795918367 0.1702127659574468 0.16326530612244897">
+					<Widget type="TextBox" skin="TextBox" name="ButtonTextCamera" position_real="0.0625 0.125 0.875 0.75">
 						<Property key="Caption" value="Player\nCamera" />
 						<Property key="TextAlign" value="Center" />
 						<Property key="NeedMouse" value="false" />
 						<Property key="NeedKey" value="false" />
 					</Widget>
 				</Widget>
-				<Widget type="Button" skin="BeaconIconBorder" name="TargetTracker" position_real="0.5 0.15 0.166667 0.25">
-					<Widget type="TextBox" skin="TextBox" name="ButtonTextTracker" position_real="0.0769231 0.0769231 0.846154 0.846154">
+				<Widget type="Button" skin="BeaconIconBorder" name="TargetTracker" position_real="0.5 0.11224489795918367 0.1702127659574468 0.16326530612244897">
+					<Widget type="TextBox" skin="TextBox" name="ButtonTextTracker" position_real="0.0625 0.125 0.875 0.75">
 						<Property key="Caption" value="Tracker" />
 						<Property key="TextAlign" value="Center" />
 						<Property key="NeedMouse" value="false" />
 						<Property key="NeedKey" value="false" />
 					</Widget>
 				</Widget>
-				<Widget type="Button" skin="BeaconIconBorder" name="TargetPlayerTracker" position_real="0.666667 0.15 0.166667 0.25">
-					<Widget type="TextBox" skin="TextBox" name="ButtonTextPlayerTracker" position_real="0.0769231 0.0769231 0.846154 0.846154">
+				<Widget type="Button" skin="BeaconIconBorder" name="TargetPlayerTracker" position_real="0.6595744680851063 0.11224489795918367 0.1702127659574468 0.16326530612244897">
+					<Widget type="TextBox" skin="TextBox" name="ButtonTextPlayerTracker" position_real="0.0625 0.125 0.875 0.75">
 						<Property key="Caption" value="Player &amp;\nTracker" />
 						<Property key="TextAlign" value="Center" />
 						<Property key="NeedMouse" value="false" />
 						<Property key="NeedKey" value="false" />
 					</Widget>
 				</Widget>
-				<Widget type="Button" skin="BeaconIconBorder" name="TargetUnits" position_real="0.833333 0.15 0.166667 0.25">
-					<Widget type="TextBox" skin="TextBox" name="ButtonTextUnits" position_real="0.0769231 0.0769231 0.846154 0.846154">
+				<Widget type="Button" skin="BeaconIconBorder" name="TargetUnits" position_real="0.8297872340425532 0.11224489795918367 0.1702127659574468 0.16326530612244897">
+					<Widget type="TextBox" skin="TextBox" name="ButtonTextUnits" position_real="0.0625 0.125 0.875 0.75">
 						<Property key="Caption" value="Units" />
 						<Property key="TextAlign" value="Center" />
 						<Property key="NeedMouse" value="false" />
 						<Property key="NeedKey" value="false" />
 					</Widget>
 				</Widget>
-
-				<!-- Options -->
-				<Widget type="TextBox" skin="TextBox" name="HeadingOptions" position_real="0 0.45 1 0.1">
+				<Widget type="TextBox" skin="TextBox" name="HeadingOptions" position_real="0 0.3510204081632653 0.9957446808510638 0.0673469387755102">
 					<Property key="Caption" value="Options" />
 					<Property key="TextAlign" value="Left VCenter" />
 					<Property key="FontName" value="SM_ButtonSmallBold" />
 				</Widget>
-
-				<!-- Option: Predictive -->
-				<Widget type="Button" skin="BeaconIconBorder" name="OptionPredictive" position_real="0 0.6 0.066666 0.1">
-					<Widget type="TextBox" skin="TextBox" name="OptionPredictiveCheck" position_real="0 0 1 1">
+				<Widget type="Button" skin="BeaconIconBorder" name="OptionPredictive" position_real="0 0.43673469387755104 0.06595744680851064 0.0673469387755102">
+					<Widget type="TextBox" skin="TextBox" name="OptionPredictiveCheck" position_real="0 0 0.967741935483871 0.7575757575757576">
 						<Property key="Caption" value="x" />
 						<Property key="TextAlign" value="Center" />
 						<Property key="NeedKey" value="false" />
 						<Property key="NeedMouse" value="false" />
 					</Widget>
 				</Widget>
-				<Widget type="TextBox" skin="TextBox" name="OptionPredictiveLabel" position_real="0.1 0.6 0.4 0.1">
+				<Widget type="TextBox" skin="TextBox" name="OptionPredictiveLabel" position_real="0.1 0.43673469387755104 0.39787234042553193 0.0673469387755102">
 					<Property key="Caption" value="Predictive" />
 					<Property key="TextAlign" value="Left VCenter" />
 				</Widget>
-
-				<Widget type="Widget" skin="PanelEmpty" name="Units" position_real="0 0.45 1 0.6">
-					<Widget type="Button" skin="BeaconIconBorder" name="UnitsAll" position_real="0 0 0.166667 0.25">
-						<Widget type="TextBox" skin="TextBox" position_real="0.0769231 0.0769231 0.846154 0.846154">
+				<Widget type="Button" skin="BeaconIconBorder" name="OptionLocal" position_real="0 0.5224489795918368 0.06595744680851064 0.0673469387755102">
+					<Widget type="TextBox" skin="TextBox" name="OptionLocalCheck" position_real="0 0 0.967741935483871 0.7575757575757576">
+						<Property key="Caption" value="x" />
+						<Property key="TextAlign" value="Center" />
+						<Property key="NeedKey" value="false" />
+						<Property key="NeedMouse" value="false" />
+					</Widget>
+				</Widget>
+				<Widget type="TextBox" skin="TextBox" name="OptionLocalLabel" position_real="0.1 0.5224489795918368 0.39787234042553193 0.0673469387755102">
+					<Property key="Caption" value="Local" />
+					<Property key="TextAlign" value="Left VCenter" />
+				</Widget>
+				<Widget type="Widget" skin="PanelEmpty" name="Units" position_real="0 0.6122448979591837 1 0.3673469387755102">
+					<Widget type="Button" skin="BeaconIconBorder" name="UnitsAll" position_real="0 0 0.16595744680851063 0.2111111111111111">
+						<Widget type="TextBox" skin="TextBox" position_real="0.07692307692307693 0.07894736842105263 0.8461538461538461 0.8421052631578947">
 							<Property key="Caption" value="All" />
 							<Property key="TextAlign" value="Center" />
 							<Property key="NeedMouse" value="false" />
 							<Property key="NeedKey" value="false" />
 						</Widget>
 					</Widget>
-					<Widget type="Button" skin="BeaconIconBorder" name="UnitsHostile" position_real="0.166667 0 0.166667 0.25">
-						<Widget type="TextBox" skin="TextBox" position_real="0.0769231 0.0769231 0.846154 0.846154">
+					<Widget type="Button" skin="BeaconIconBorder" name="UnitsHostile" position_real="0.16595744680851063 0 0.16595744680851063 0.2111111111111111">
+						<Widget type="TextBox" skin="TextBox" position_real="0.07692307692307693 0.07894736842105263 0.8461538461538461 0.8421052631578947">
 							<Property key="Caption" value="Hostile" />
 							<Property key="TextAlign" value="Center" />
 							<Property key="NeedMouse" value="false" />
 							<Property key="NeedKey" value="false" />
 						</Widget>
 					</Widget>
-					<Widget type="Button" skin="BeaconIconBorder" name="UnitsFriendly" position_real="0.333333 0 0.166667 0.25">
-						<Widget type="TextBox" skin="TextBox" position_real="0.0769231 0.0769231 0.846154 0.846154">
+					<Widget type="Button" skin="BeaconIconBorder" name="UnitsFriendly" position_real="0.33191489361702126 0 0.16595744680851063 0.2111111111111111">
+						<Widget type="TextBox" skin="TextBox" position_real="0.07692307692307693 0.07894736842105263 0.8461538461538461 0.8421052631578947">
 							<Property key="Caption" value="Friendly" />
 							<Property key="TextAlign" value="Center" />
 							<Property key="NeedMouse" value="false" />
 							<Property key="NeedKey" value="false" />
 						</Widget>
 					</Widget>
-
-					<!-- Row 2 -->
-					<Widget type="Button" skin="BeaconIconBorder" name="UnitsFarmbot" position_real="0 0.333333 0.166667 0.25">
-						<Widget type="TextBox" skin="TextBox" position_real="0.0769231 0.0769231 0.846154 0.846154">
+					<Widget type="Button" skin="BeaconIconBorder" name="UnitsFarmbot" position_real="0 0.2222222222222222 0.16595744680851063 0.2">
+						<Widget type="TextBox" skin="TextBox" position_real="0.07692307692307693 0.08333333333333333 0.8461538461538461 0.8333333333333334">
 							<Property key="Caption" value="Farmbot" />
 							<Property key="TextAlign" value="Center" />
 							<Property key="NeedMouse" value="false" />
 							<Property key="NeedKey" value="false" />
 						</Widget>
 					</Widget>
-					<Widget type="Button" skin="BeaconIconBorder" name="UnitsTapebot" position_real="0.166667 0.333333 0.166667 0.25">
-						<Widget type="TextBox" skin="TextBox" position_real="0.0769231 0.0769231 0.846154 0.846154">
+					<Widget type="Button" skin="BeaconIconBorder" name="UnitsTapebot" position_real="0.16595744680851063 0.2222222222222222 0.16595744680851063 0.2">
+						<Widget type="TextBox" skin="TextBox" position_real="0.07692307692307693 0.08333333333333333 0.8461538461538461 0.8333333333333334">
 							<Property key="Caption" value="Tapebot" />
 							<Property key="TextAlign" value="Center" />
 							<Property key="NeedMouse" value="false" />
 							<Property key="NeedKey" value="false" />
 						</Widget>
 					</Widget>
-					<Widget type="Button" skin="BeaconIconBorder" name="UnitsHaybot" position_real="0.333333 0.333333 0.166667 0.25">
-						<Widget type="TextBox" skin="TextBox" position_real="0.0769231 0.0769231 0.846154 0.846154">
+					<Widget type="Button" skin="BeaconIconBorder" name="UnitsHaybot" position_real="0.33191489361702126 0.2222222222222222 0.16595744680851063 0.2">
+						<Widget type="TextBox" skin="TextBox" position_real="0.07692307692307693 0.08333333333333333 0.8461538461538461 0.8333333333333334">
 							<Property key="Caption" value="Haybot" />
 							<Property key="TextAlign" value="Center" />
 							<Property key="NeedMouse" value="false" />
 							<Property key="NeedKey" value="false" />
 						</Widget>
 					</Widget>
-					<Widget type="Button" skin="BeaconIconBorder" name="UnitsTotebot" position_real="0.5 0.333333 0.166667 0.25">
-						<Widget type="TextBox" skin="TextBox" position_real="0.0769231 0.0769231 0.846154 0.846154">
+					<Widget type="Button" skin="BeaconIconBorder" name="UnitsTotebot" position_real="0.4978723404255319 0.2222222222222222 0.16595744680851063 0.2">
+						<Widget type="TextBox" skin="TextBox" position_real="0.07692307692307693 0.08333333333333333 0.8461538461538461 0.8333333333333334">
 							<Property key="Caption" value="Totebots" />
 							<Property key="TextAlign" value="Center" />
 							<Property key="NeedMouse" value="false" />
 							<Property key="NeedKey" value="false" />
 						</Widget>
 					</Widget>
-
-					<!-- Row 3 -->
-					<Widget type="Button" skin="BeaconIconBorder" name="UnitsWoc" position_real="0 0.65 0.166667 0.25">
-						<Widget type="TextBox" skin="TextBox" position_real="0.0769231 0.0769231 0.846154 0.846154">
+					<Widget type="Button" skin="BeaconIconBorder" name="UnitsTotebotYellow" position_real="0 0.4444444444444444 0.1702127659574468 0.25">
+						<Widget type="TextBox" skin="TextBox" position_real="0.0625 0.1111111111111111 0.875 0.7777777777777778">
+							<Property key="Caption" value="Totebot\nYellow" />
+							<Property key="TextAlign" value="Center" />
+							<Property key="NeedMouse" value="false" />
+							<Property key="NeedKey" value="false" />
+						</Widget>
+					</Widget>
+					<Widget type="Button" skin="BeaconIconBorder" name="UnitsTotebotRed" position_real="0.1702127659574468 0.4444444444444444 0.1595744680851064 0.25">
+						<Widget type="TextBox" skin="TextBox" position_real="0.06666666666666667 0.1111111111111111 0.8666666666666667 0.7777777777777778">
+							<Property key="Caption" value="Totebot\nRed" />
+							<Property key="TextAlign" value="Center" />
+							<Property key="NeedMouse" value="false" />
+							<Property key="NeedKey" value="false" />
+						</Widget>
+					</Widget>
+					<Widget type="Button" skin="BeaconIconBorder" name="UnitsTotebotBlue" position_real="0.32978723404255317 0.4444444444444444 0.1702127659574468 0.25">
+						<Widget type="TextBox" skin="TextBox" position_real="0.0625 0.1111111111111111 0.875 0.7777777777777778">
+							<Property key="Caption" value="Totebot\nBlue" />
+							<Property key="TextAlign" value="Center" />
+							<Property key="NeedMouse" value="false" />
+							<Property key="NeedKey" value="false" />
+						</Widget>
+					</Widget>
+					<Widget type="Button" skin="BeaconIconBorder" name="UnitsWoc" position_real="0.1702127659574468 0.6944444444444444 0.1595744680851064 0.2777777777777778">
+						<Widget type="TextBox" skin="TextBox" position_real="0.06666666666666667 0.1 0.8666666666666667 0.7">
 							<Property key="Caption" value="Wocs" />
 							<Property key="TextAlign" value="Center" />
 							<Property key="NeedMouse" value="false" />
 							<Property key="NeedKey" value="false" />
 						</Widget>
 					</Widget>
-					<Widget type="Button" skin="BeaconIconBorder" name="UnitsGlowworm" position_real="0.166667 0.65 0.166667 0.25">
-						<Widget type="TextBox" skin="TextBox" position_real="0.0769231 0.0769231 0.846154 0.846154">
+					<Widget type="Button" skin="BeaconIconBorder" name="UnitsGlowworm" position_real="0 0.6944444444444444 0.1702127659574468 0.2777777777777778">
+						<Widget type="TextBox" skin="TextBox" position_real="0.0625 0.1 0.875 0.9">
 							<Property key="Caption" value="Glow\nworms" />
-							<Property key="TextAlign" value="Center" />
+							<Property key="TextAlign" value="HCenter Top" />
 							<Property key="NeedMouse" value="false" />
 							<Property key="NeedKey" value="false" />
 						</Widget>
 					</Widget>
 				</Widget>
-
-				<!-- Option: Local -->
-				<Widget type="Button" skin="BeaconIconBorder" name="OptionLocal" position_real="0 0.7 0.066666 0.1">
-					<Widget type="TextBox" skin="TextBox" name="OptionLocalCheck" position_real="0 0 1 1">
-						<Property key="Caption" value="x" />
-						<Property key="TextAlign" value="Center" />
-						<Property key="NeedKey" value="false" />
-						<Property key="NeedMouse" value="false" />
-					</Widget>
-				</Widget>
-				<Widget type="TextBox" skin="TextBox" name="OptionLocalLabel" position_real="0.1 0.7 0.4 0.1">
-					<Property key="Caption" value="Local" />
-					<Property key="TextAlign" value="Left VCenter" />
-				</Widget>
 			</Widget>
 		</Widget>
-		<Widget type="Widget" skin="BeaconBottomBG" position_real="0 0.716157 1 0.283843">
-			<Widget type="TextBox" skin="TextBox" name="FunctionNameText" position_real="0.15 0.123077 0.70 0.2">
+		<Widget type="Widget" skin="BeaconBottomBG" position_real="0 0.7638888888888888 1 0.23148148148148148">
+			<Widget type="TextBox" skin="TextBox" name="FunctionNameText" position_real="0.14901960784313725 0.065 0.7 0.195">
 				<Property key="Caption" value="Function" />
 				<Property key="FontName" value="SM_ButtonSmallBold" />
 				<Property key="TextAlign" value="Center" />
 			</Widget>
-			<Widget type="EditBox" skin="EditBoxEmpty" name="FunctionDescriptionText" position_real="0.15 0.3 0.70 0.55">
+			<Widget type="EditBox" skin="EditBoxEmpty" name="FunctionDescriptionText" position_real="0.14901960784313725 0.29 0.7 0.325">
 				<Property key="Static" value="true" />
 				<Property key="Caption" value="Function description" />
 				<Property key="FontName" value="SM_TextLabel" />
@@ -202,5 +214,4 @@
 			</Widget>
 		</Widget>
 	</Widget>
-	<CodeGeneratorSettings />
 </MyGUI>

--- a/Scripts/interactable/Orientation/Orienter.lua
+++ b/Scripts/interactable/Orientation/Orienter.lua
@@ -15,9 +15,16 @@ local known_mobs = {
 			["68d3b2f3-ed4b-4967-9d22-8ee6f555df63"] = true,
 			["c3d31c47-0c9b-4b07-9bd4-8f022dc4333e"] = true
 		},
-		totebot = {["8984bdbf-521e-4eed-b3c4-2b5e287eb879"] = true},
+		totebot = {
+			["8984bdbf-521e-4eed-b3c4-2b5e287eb879"] = true, --normal
+			["55fd93fa-09ed-4a26-bfa1-4601694d5127"] = true  --bush
+		},
+		totebot_yellow = {["2dea48a4-6a79-11ed-a1eb-0242ac120002"] = true},
+		totebot_blue = {["58992f50-ca36-44e1-8c47-4996d89d6a9a"] = true},
+		totebot_red = {["9360d346-3ff2-4925-a068-660cf5dd5267"] = true},
 		haybot = {["c8bfb8f3-7efc-49ac-875a-eb85ac0614db"] = true},
-		farmbot = {["9f4fde94-312f-4417-b13b-84029c5d6b52"] = true}
+		farmbot = {["9f4fde94-312f-4417-b13b-84029c5d6b52"] = true},
+		minerbot = {["92da8324-3cfe-4529-ac1c-c71facda50a3"] = true}
 	},
 	friendly = {
 		glorp = {["48c03f69-3ec8-454c-8d1a-fa09083363b1"] = true},
@@ -34,7 +41,10 @@ local FarmbotDetectorModes = {
 	[25] = {hostile = true, friendly = true},
 	[26] = {friendly = true},
 	[27] = {specific = "woc"},
-	[28] = {specific = "glorp"}
+	[28] = {specific = "glorp"},
+	[29] = {hostile = true, specific = "totebot_yellow"},
+	[30] = {hostile = true, specific = "totebot_red"},
+	[31] = {hostile = true, specific = "totebot_blue"}
 }
 
 --[[
@@ -120,7 +130,22 @@ Orienter.modetable = {
 	{savevalue = 24, target = "units", unit = "totebot", loc = false, predictive = false, name = "Hostile totebot" },
 	{savevalue = 26, target = "units", unit = "friendly", loc = false, predictive = false, name = "Friendly units" },
 	{savevalue = 27, target = "units", unit = "woc", loc = false, predictive = false, name = "Woc" },
-	{savevalue = 28, target = "units", unit = "glowworm", loc = false, predictive = false, name = "Glow worm" }
+	{savevalue = 28, target = "units", unit = "glowworm", loc = false, predictive = false, name = "Glow worm" },
+	{savevalue = 29, target = "units", unit = "totebot_yellow", loc = false, predictive = false, name = "Hostile totebot yellow", uvIndex = 23 },
+	{savevalue = 30, target = "units", unit = "totebot_red", loc = false, predictive = false, name = "Hostile totebot red", uvIndex = 23 },
+	{savevalue = 31, target = "units", unit = "totebot_blue", loc = false, predictive = false, name = "Hostile totebot blue", uvIndex = 23 },
+	{savevalue = 32, target = "units", unit = "hostile", loc = false, predictive = true, name = "Hostile units (predictive)", uvIndex = 19 },
+	{savevalue = 33, target = "units", unit = "farmbot", loc = false, predictive = true, name = "Hostile farmbot (predictive)", uvIndex = 20 },
+	{savevalue = 34, target = "units", unit = "tapebot", loc = false, predictive = true, name = "Hostile tapebot (predictive)", uvIndex = 21 },
+	{savevalue = 35, target = "units", unit = "haybot", loc = false, predictive = true, name = "Hostile haybot (predictive)", uvIndex = 22 },
+	{savevalue = 36, target = "units", unit = "totebot", loc = false, predictive = true, name = "Hostile totebot (predictive)", uvIndex = 23 },
+	{savevalue = 37, target = "units", unit = "all", loc = false, predictive = true, name = "All units (predictive)", uvIndex = 24 },
+	{savevalue = 38, target = "units", unit = "friendly", loc = false, predictive = true, name = "Friendly units (predictive)", uvIndex = 25 },
+	{savevalue = 39, target = "units", unit = "woc", loc = false, predictive = true, name = "Woc (predictive)", uvIndex = 26 },
+	{savevalue = 40, target = "units", unit = "glowworm", loc = false, predictive = true, name = "Glow worm (predictive)", uvIndex = 27 },
+	{savevalue = 41, target = "units", unit = "totebot_yellow", loc = false, predictive = true, name = "Hostile totebot yellow (predictive)", uvIndex = 23 },
+	{savevalue = 42, target = "units", unit = "totebot_red", loc = false, predictive = true, name = "Hostile totebot red (predictive)", uvIndex = 23 },
+	{savevalue = 43, target = "units", unit = "totebot_blue", loc = false, predictive = true, name = "Hostile totebot blue (predictive)", uvIndex = 23 }
 }
 Orienter.modeIndexBySaveValue = {}
 for k, v in pairs(Orienter.modetable) do
@@ -166,7 +191,8 @@ function Orienter.client_onDestroy(self)
 end
 
 function Orienter.sv_sendModeToClient(self)
-	local _UvIndex = self.modetable[self.mode].savevalue - 1
+	local modeEntry = self.modetable[self.mode]
+	local _UvIndex = modeEntry.uvIndex or (modeEntry.savevalue - 1)
 	self.network:sendToClients("cl_setMode", { uvIndex = _UvIndex, mode = self.mode })
 end
 
@@ -183,7 +209,7 @@ local targetTable = {
 local _UnitTable = {
 	'UnitsAll', 'UnitsHostile', 'UnitsFriendly',
 	'UnitsFarmbot', 'UnitsTapebot', 'UnitsHaybot',
-	'UnitsTotebot', 'UnitsWoc', 'UnitsGlowworm'
+	'UnitsTotebot', 'UnitsTotebotYellow', 'UnitsTotebotRed', 'UnitsTotebotBlue', 'UnitsWoc', 'UnitsGlowworm'
 }
 
 function Orienter.client_onGuiDestroyCallback(self)
@@ -228,6 +254,9 @@ function Orienter.cl_onUnitButtonClick(self, buttonName)
     	UnitsTapebot = 22,
     	UnitsHaybot = 23,
     	UnitsTotebot = 24,
+    	UnitsTotebotYellow = 29,
+    	UnitsTotebotRed = 30,
+    	UnitsTotebotBlue = 31,
     	UnitsFriendly = 26,
     	UnitsWoc = 27,
     	UnitsGlowworm = 28
@@ -263,7 +292,19 @@ function Orienter.cl_onPredictiveToggle(self, button)
         [17] = 18,
         [18] = 17,
         [19] = 16,
-        [16] = 19
+        [16] = 19,
+        [20] = 32, [32] = 20,
+        [21] = 33, [33] = 21,
+        [22] = 34, [34] = 22,
+        [23] = 35, [35] = 23,
+        [24] = 36, [36] = 24,
+        [25] = 37, [37] = 25,
+        [26] = 38, [38] = 26,
+        [27] = 39, [39] = 27,
+        [28] = 40, [40] = 28,
+        [29] = 41, [41] = 29,
+        [30] = 42, [42] = 30,
+        [31] = 43, [43] = 31
     }
     self:cl_handleChageModeFromGui(Orienter.modeIndexBySaveValue[inverse[currentMode.savevalue]])
 end
@@ -324,7 +365,7 @@ function Orienter.cl_onTargetButtonClick(self, buttonName)
         end
     elseif buttonName == 'TargetUnits' then
         if currentMode.target ~= 'units' then
-            newModeValue = 25
+            newModeValue = pred and 37 or 25
         end
     end
 
@@ -341,7 +382,7 @@ local _buttonData = {
 	camera = {pred = true, loc = true, mode = 'TargetCamera'},
 	tracker = {pred = true, loc = true, mode = 'TargetTracker'},
 	playertracker = {pred = true, loc = true, mode = 'TargetPlayerTracker'},
-	units = {unit = true, mode = 'TargetUnits'},
+	units = {unit = true, pred = true, mode = 'TargetUnits'},
 	distance = {mode = 'TargetDistance'}
 }
 
@@ -370,7 +411,7 @@ function Orienter.cl_drawButtons(self)
 
 	if _Unit then
 		for _, btnName in pairs(_UnitTable) do
-			self.gui:setButtonState(btnName, btnName:lower() == 'units' .. mode.unit)
+			self.gui:setButtonState(btnName, btnName:lower() == 'units' .. mode.unit:gsub('_', ''))
 		end
 	end
 
@@ -382,7 +423,8 @@ function Orienter.sv_changeMode(self, params)
     self.mode = params.mode
 	self.storage:save(self.modetable[self.mode].savevalue)
 	self.network:sendToClients("client_playsound", "GUI Item drag")
-    self.network:sendToClients('cl_setMode', { mode = params.mode, uvIndex = Orienter.modetable[params.mode].savevalue - 1 })
+    local newModeEntry = Orienter.modetable[params.mode]
+    self.network:sendToClients('cl_setMode', { mode = params.mode, uvIndex = newModeEntry.uvIndex or (newModeEntry.savevalue - 1) })
 end
 
 function Orienter.client_canInteract(self)
@@ -900,8 +942,10 @@ function Orienter.server_onFixedUpdate( self, dt )
 		-- mode '12' -> 11-7 = 3--> player orient local
 	end
 
-	if (mode >= 20 and mode <= 28) then
-		local id = self:getFarmbot({useexceptionlist = true, minrange = minrange, maxrange = maxrange, offset = blackinput, tryid = whiteinput, fbot_data = FarmbotDetectorModes[mode]})
+	if (mode >= 20 and mode <= 43) then
+		local farmbotMode = mode > 31 and (mode - 12) or mode
+		local isPredictive = mode > 31
+		local id = self:getFarmbot({useexceptionlist = true, minrange = minrange, maxrange = maxrange, offset = blackinput, tryid = whiteinput, fbot_data = FarmbotDetectorModes[farmbotMode]})
 		if id ~= 0 and isON then
 			for k, v in pairs(parents) do
 				local _sUuid = tostring(v:getShape():getShapeUuid())
@@ -913,15 +957,19 @@ function Orienter.server_onFixedUpdate( self, dt )
 			targetmass = allunits[id].character.mass
 			targetdir = allunits[id].character.direction
 
-			local targetdirection = (allunits[id].character.worldPosition - self.shape.worldPosition):normalize()
-			local distance = (allunits[id].character.worldPosition - self.shape.worldPosition):length()
+			if isPredictive then
+				predictmove(self, self.shape.worldPosition, eye, allunits[id].character.worldPosition, false)
+			else
+				local targetdirection = (allunits[id].character.worldPosition - self.shape.worldPosition):normalize()
+				local distance = (allunits[id].character.worldPosition - self.shape.worldPosition):length()
 
-			local pitch, yaw = 0, 0
-			pitch, yaw = self:calcpitchandyaw({direction = eye, targetdirection = targetdirection})
+				local pitch, yaw = 0, 0
+				pitch, yaw = self:calcpitchandyaw({direction = eye, targetdirection = targetdirection})
 
-			self.pitch = pitch
-			self.yaw = yaw
-			self.pose1 = ((1/(4*distance)) and 1/(4*distance) or 1)
+				self.pitch = pitch
+				self.yaw = yaw
+				self.pose1 = ((1/(4*distance)) and 1/(4*distance) or 1)
+			end
 		else
 			self.pitch = 0
 			self.yaw = 0
@@ -1409,7 +1457,8 @@ end
 function Orienter.client_onUpdatee(self, dt)
 	if not sm.isServer then return end
 
-	self.interactable:setUvFrameIndex(self.modetable[self.mode].savevalue-1)
+	local modeEntry = self.modetable[self.mode]
+	self.interactable:setUvFrameIndex(modeEntry.uvIndex or (modeEntry.savevalue - 1))
 	self.interactable:setPoseWeight(0, self.pose0)
 	self.interactable:setPoseWeight(1, self.pose1)
 end

--- a/Scripts/interactable/Orientation/Orienter.lua
+++ b/Scripts/interactable/Orientation/Orienter.lua
@@ -24,7 +24,8 @@ local known_mobs = {
 		totebot_red = {["9360d346-3ff2-4925-a068-660cf5dd5267"] = true},
 		haybot = {["c8bfb8f3-7efc-49ac-875a-eb85ac0614db"] = true},
 		farmbot = {["9f4fde94-312f-4417-b13b-84029c5d6b52"] = true},
-		minerbot = {["92da8324-3cfe-4529-ac1c-c71facda50a3"] = true}
+		minerbot = {["92da8324-3cfe-4529-ac1c-c71facda50a3"] = true},
+		cablebot = {["b837888a-0480-4a34-bc34-d72261a14385"] = true}
 	},
 	friendly = {
 		glorp = {["48c03f69-3ec8-454c-8d1a-fa09083363b1"] = true},
@@ -44,7 +45,8 @@ local FarmbotDetectorModes = {
 	[28] = {specific = "glorp"},
 	[29] = {hostile = true, specific = "totebot_yellow"},
 	[30] = {hostile = true, specific = "totebot_red"},
-	[31] = {hostile = true, specific = "totebot_blue"}
+	[31] = {hostile = true, specific = "totebot_blue"},
+	[44] = {hostile = true, specific = "cablebot"}
 }
 
 --[[
@@ -145,7 +147,9 @@ Orienter.modetable = {
 	{savevalue = 40, target = "units", unit = "glowworm", loc = false, predictive = true, name = "Glow worm (predictive)", uvIndex = 27 },
 	{savevalue = 41, target = "units", unit = "totebot_yellow", loc = false, predictive = true, name = "Hostile totebot yellow (predictive)", uvIndex = 23 },
 	{savevalue = 42, target = "units", unit = "totebot_red", loc = false, predictive = true, name = "Hostile totebot red (predictive)", uvIndex = 23 },
-	{savevalue = 43, target = "units", unit = "totebot_blue", loc = false, predictive = true, name = "Hostile totebot blue (predictive)", uvIndex = 23 }
+	{savevalue = 43, target = "units", unit = "totebot_blue", loc = false, predictive = true, name = "Hostile totebot blue (predictive)", uvIndex = 23 },
+	{savevalue = 44, target = "units", unit = "cablebot", loc = false, predictive = false, name = "Hostile cablebot", uvIndex = 19 },
+	{savevalue = 56, target = "units", unit = "cablebot", loc = false, predictive = true, name = "Hostile cablebot (predictive)", uvIndex = 19 }
 }
 Orienter.modeIndexBySaveValue = {}
 for k, v in pairs(Orienter.modetable) do
@@ -209,7 +213,7 @@ local targetTable = {
 local _UnitTable = {
 	'UnitsAll', 'UnitsHostile', 'UnitsFriendly',
 	'UnitsFarmbot', 'UnitsTapebot', 'UnitsHaybot',
-	'UnitsTotebot', 'UnitsTotebotYellow', 'UnitsTotebotRed', 'UnitsTotebotBlue', 'UnitsWoc', 'UnitsGlowworm'
+	'UnitsTotebot', 'UnitsTotebotYellow', 'UnitsTotebotRed', 'UnitsTotebotBlue', 'UnitsCablebot', 'UnitsWoc', 'UnitsGlowworm'
 }
 
 function Orienter.client_onGuiDestroyCallback(self)
@@ -257,6 +261,7 @@ function Orienter.cl_onUnitButtonClick(self, buttonName)
     	UnitsTotebotYellow = 29,
     	UnitsTotebotRed = 30,
     	UnitsTotebotBlue = 31,
+    	UnitsCablebot = 44,
     	UnitsFriendly = 26,
     	UnitsWoc = 27,
     	UnitsGlowworm = 28
@@ -304,7 +309,8 @@ function Orienter.cl_onPredictiveToggle(self, button)
         [28] = 40, [40] = 28,
         [29] = 41, [41] = 29,
         [30] = 42, [42] = 30,
-        [31] = 43, [43] = 31
+        [31] = 43, [43] = 31,
+        [44] = 56, [56] = 44
     }
     self:cl_handleChageModeFromGui(Orienter.modeIndexBySaveValue[inverse[currentMode.savevalue]])
 end
@@ -942,7 +948,7 @@ function Orienter.server_onFixedUpdate( self, dt )
 		-- mode '12' -> 11-7 = 3--> player orient local
 	end
 
-	if (mode >= 20 and mode <= 43) then
+	if (mode >= 20 and mode <= 56) then
 		local farmbotMode = mode > 31 and (mode - 12) or mode
 		local isPredictive = mode > 31
 		local id = self:getFarmbot({useexceptionlist = true, minrange = minrange, maxrange = maxrange, offset = blackinput, tryid = whiteinput, fbot_data = FarmbotDetectorModes[farmbotMode]})


### PR DESCRIPTION
Added chapter 2 bot support to the Orienter block.

**known_mobs**
- Added totebot (bush), totebot_yellow, totebot_blue, totebot_red
- Added cablebot

**New targeting modes (savevalues 29-31, 44)**
- 29: Hostile totebot yellow
- 30: Hostile totebot red
- 31: Hostile totebot blue
- 44: Hostile cablebot

**Predictive modes for all unit targets (savevalues 32-43, 56)**
- Every unit mode now has a predictive variant using predictmove()
- Predictive checkbox is now shown in the GUI for unit targets

**GUI (Orienter.layout)**
- Buttons for Totebot Yellow, Red, Blue, Cablebot
- Options (Predictive / Local) moved above the Units section -- no more overlap
- Fixed button highlight: mode.unit comparison now strips underscores via :gsub('_', '')
- Enlarged window height, shrunk bottom description panel

**UV frame**
- savevalues without dedicated atlas frames use uvIndex pointing to the closest matching icon